### PR TITLE
Set 800 character maximum length for newsletter spots

### DIFF
--- a/packages.md
+++ b/packages.md
@@ -17,7 +17,7 @@ Price: €99
 Perks:
 
 - A tweet from us mentioning you on Twitter.
-- A spot on our monthly newsletter sent to our members.
+- A spot on our monthly newsletter sent to our members (max. 800 chars.).
 
 ## Level II
 
@@ -26,7 +26,7 @@ Price: €149
 Perks:
 
 - A tweet from us mentioning you on Twitter.
-- A spot on our monthly newsletter sent to our members.
+- A spot on our monthly newsletter sent to our members (max. 800 chars.).
 - 3 minute talk slot at the meetup.
 
 ## Level III
@@ -36,6 +36,6 @@ Price: €199
 Perks:
 
 - A tweet from us mentioning you on Twitter.
-- A spot on our monthly newsletter sent to our members.
+- A spot on our monthly newsletter sent to our members (max. 800 chars.).
 - 3 minute talk slot at the meetup.
 - A sweet spot on our sponsor hall of fame.


### PR DESCRIPTION
An 800 character text looks like this:

>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at nibh elementum imperdiet. Duis sagittis ipsum. Praesent mauris. Fusce nec tellus sed augue semper porta. Mauris massa. Vestibulum lacinia arcu eget nulla. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Curabitur sodales ligula in libero. Sed dignissim lacinia nunc. Curabitur tortor. Pellentesque nibh. Aenean quam. In scelerisque sem at dolor. Maecenas mattis. Sed convallis tristique sem. Proin ut ligula vel nunc egestas porttitor. Morbi lectus risus, iaculis vel, suscipit quis, luctus non, massa. Fusce ac turpis quis ligula lacinia aliquet. Mauris ipsum. Nulla metus metus, ullamcorper, tincidunt...

I think this is a good length for a newsletter spot, but I'd appreciate your input!